### PR TITLE
Add a bloom-filter test with many rules (instead of many selectors on one rule)

### DIFF
--- a/perf-reftest/bloom-basic-2.html
+++ b/perf-reftest/bloom-basic-2.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="util.js"></script>
+    <script>
+window.onload = function() {
+  /* Use many rules, instead of one rule with many selectors, to test per-rule overhead. */
+  document.head.appendChild(build_rule("span div", 1, '{ color: blue; } ', 10000));
+  let dom = build_dom(5000, "div");
+
+  perf_start();
+  document.body.appendChild(dom);
+  window.foo = window.getComputedStyle(document.body).color;
+  perf_finish();
+}
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/perf-reftest/util.js
+++ b/perf-reftest/util.js
@@ -15,9 +15,11 @@ function build_dom(n, elemName) {
   return ours;
 }
 
-function build_rule(selector, selectorRepeat, declaration) {
+function build_rule(selector, selectorRepeat, declaration, ruleRepeat) {
+  ruleRepeat = ruleRepeat || 1;
   var s = document.createElement("style");
-  s.textContent = Array(selectorRepeat).fill(selector).join(", ") + declaration;
+  var rule = Array(selectorRepeat).fill(selector).join(", ") + declaration;
+  s.textContent = Array(ruleRepeat).fill(rule).join("\n\n");
   return s;
 }
 


### PR DESCRIPTION
The results in Gecko are the same as the other bloom tests, which is why we don't need a new ref.

Stylo performs 7.5x worse than bloom-basic-ref on this testcase without bug 1358375, and performs the same as bloom-basic-ref with the patch in that bug.